### PR TITLE
spring-boot-parent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,15 @@
 # Declare text files with unix file ending
+*.cfg text eol=lf
 *.conf text eol=lf
 *.config text eol=lf
 *.css text eol=lf
 *.dtd text eol=lf
 *.esp text eol=lf
 *.ecma text eol=lf
+*.gdsl text eol=lf
+*.groovy text eol=lf
 *.hbrs text eol=lf
+*.hbs text eol=lf
 *.htm text eol=lf
 *.html text eol=lf
 *.java text eol=lf
@@ -13,6 +17,7 @@
 *.js text eol=lf
 *.json text eol=lf
 *.jsp text eol=lf
+*.md text eol=lf
 *.mustache text eol=lf
 *.tld text eol=lf
 *.launch text eol=lf
@@ -22,6 +27,7 @@
 *.project text eol=lf
 *.properties text eol=lf
 *.props text eol=lf
+*.py text eol=lf
 *.sass text eol=lf
 *.scss text eol=lf
 *.sh text eol=lf
@@ -29,12 +35,15 @@
 *.shtml text eol=lf
 *.sql text eol=lf
 *.svg text eol=lf
+*.tf text eol=lf
 *.txt text eol=lf
 *.vm text eol=lf
 *.xml text eol=lf
 *.xsd text eol=lf
 *.xsl text eol=lf
 *.xslt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
 
 
 # Declare windows-specific text files with windows file ending

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ pom.xml.versionsBackup
 pom.xml.next
 release.properties
 maven-eclipse.xml
+infinitest.filters
 
 node_modules/
 npm-debug.log
@@ -17,10 +18,16 @@ npm-debug.log
 .pmd
 .checkstyle
 .idea
-.iml
+.vagrant
+*.iml
 .DS_Store
+*.retry
 .rubygems
 .sass-cache
 .rubygems-gem-maven-plugin
 *.sublime-*
+*nbactions*.xml
 .temp/
+.vlt
+.vlt-sync*
+.brackets.json

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ npm-debug.log
 .rubygems-gem-maven-plugin
 *.sublime-*
 .temp/
+
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,10 @@ npm-debug.log
 .pmd
 .checkstyle
 .idea
-.iml
+*.iml
 .DS_Store
 .rubygems
 .sass-cache
 .rubygems-gem-maven-plugin
 *.sublime-*
 .temp/
-
-*.iml

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Maven
 * [global-parent](maven/global-parent)
 * [global-build-tools-mixin](maven/global-build-tools-mixin)
 * [global-build-tools](maven/global-build-tools) (deprecated)
+
+_Spring Boot_
+
+* [spring-boot-parent](maven/spring-boot-parent)

--- a/maven/spring-boot-parent/README.md
+++ b/maven/spring-boot-parent/README.md
@@ -1,0 +1,10 @@
+spring-boot-parent
+=============
+
+Parent which allows the usage of Spring Boot in combination with the [pro-vision global-parent](https://github.com/pro-vision/pv-build-tools/tree/develop/maven/global-parent).
+
+Defines fixed versions of Spring Boot dependencies based on the following naming schema:
+
+`<version>-<spring-boot-version>` e.g. `1-2.1.8` is the first release for Spring Boot 2.1.8. 
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/de.pro-vision.maven/de.pro-vision.maven.spring.spring-boot-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/de.pro-vision.maven/de.pro-vision.maven.spring.spring-boot-parent)

--- a/maven/spring-boot-parent/changes.xml
+++ b/maven/spring-boot-parent/changes.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  pro!vision GmbH
+  %%
+  Copyright (C) pro!vision GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
+    xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
+  <body>
+
+    <release version="1-2.1.8" date="not released">
+      <action type="add" dev="amuthmann">
+        Initial release.
+      </action>
+    </release>
+
+  </body>
+</document>

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -131,7 +131,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 
@@ -191,15 +190,6 @@
       </build>
     </profile>
   </profiles>
-
-  <repositories>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestone Repository</name>
-      <url>http://repo.spring.io/milestone</url>
-    </repository>
-  </repositories>
-
 
   <distributionManagement>
     <repository>

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  pro!vision GmbH
+  %%
+  Copyright (C) pro!vision GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.pro-vision.maven</groupId>
+    <artifactId>de.pro-vision.maven.global-parent</artifactId>
+    <version>33-SNAPSHOT</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>de.pro-vision.maven.spring</groupId>
+  <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
+  <version>1-2.1.8-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>de.pro-vision.maven.spring.spring-boot-parent</name>
+  <description>Parent for Spring Boot projects using the pro-vision parent as baseline.</description>
+  <url>https://github.com/pro-vision/pv-build-tools</url>
+
+  <scm>
+    <connection>scm:git:https://github.com/pro-vision/pv-build-tools.git</connection>
+    <developerConnection>scm:git:https://github.com/pro-vision/pv-build-tools.git</developerConnection>
+    <url>https://github.com/pro-vision/pv-build-tools</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <inceptionYear>2019</inceptionYear>
+
+  <organization>
+    <name>pro!vision GmbH</name>
+    <url>http://www.pro-vision.de</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>pro!vision GmbH</name>
+      <organization>pro!vision GmbH</organization>
+      <organizationUrl>http://www.pro-vision.de</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+
+    <!-- distribution settings -->
+    <distribution.snapshotRepositoryId>ossrh</distribution.snapshotRepositoryId>
+    <distribution.snapshotRepositoryUrl>https://oss.sonatype.org/content/repositories/snapshots</distribution.snapshotRepositoryUrl>
+    <distribution.releaseRepositoryId>ossrh</distribution.releaseRepositoryId>
+    <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
+
+    <!-- versions -->
+    <spring-boot.version>2.1.8.RELEASE</spring-boot.version>
+    <spring-cloud.version>Greenwich.SR2</spring-cloud.version>
+    <spring-cloud-netflix.version>2.1.2.RELEASE</spring-cloud-netflix.version>
+    <spring-cloud-kubernetes.version>1.0.2.RELEASE</spring-cloud-kubernetes.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-configuration-processor</artifactId>
+        <optional>true</optional>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring-cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-netflix</artifactId>
+        <version>${spring-cloud-netflix.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-netflix-dependencies</artifactId>
+        <version>${spring-cloud-netflix.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <!-- release-profile -->
+    <profile>
+      <id>release-profile</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- sign the build (only for this pom, not inherited)  -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- configure staging process at sonatype (only for this pom, not inherited) -->
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <inherited>false</inherited>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <!-- Deployed artifacts should go to staging to be reviewed before publish -->
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <repositories>
+    <repository>
+      <id>spring-milestones</id>
+      <name>Spring Milestone Repository</name>
+      <url>http://repo.spring.io/milestone</url>
+    </repository>
+  </repositories>
+
+
+  <distributionManagement>
+    <repository>
+      <id>${distribution.releaseRepositoryId}</id>
+      <url>${distribution.releaseRepositoryUrl}</url>
+    </repository>
+    <snapshotRepository>
+      <id>${distribution.snapshotRepositoryId}</id>
+      <url>${distribution.snapshotRepositoryUrl}</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
   <modules>
     <module>maven/global-parent</module>
     <module>maven/global-build-tools-mixin</module>
+    <module>maven/spring-boot-parent</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This is a proposal for a global parent for spring-boot based projects.
Basically it uses the pv global-parent and adds the required spring boot dependencies (or at least a good part of those).

I currently don't know, if we should also add the required configuration for Docker Images (see https://www.dev-eth0.de/2019/07/29/dockerize-spring-boot-applications/) which changes the build process a bit but might be helpful. 

