### PR TITLE
spring-boot-parent: Configuration for Docker

### DIFF
--- a/maven/spring-boot-parent/README.md
+++ b/maven/spring-boot-parent/README.md
@@ -7,4 +7,35 @@ Defines fixed versions of Spring Boot dependencies based on the following naming
 
 `<version>-<spring-boot-version>` e.g. `1-2.1.8` is the first release for Spring Boot 2.1.8. 
 
+## Docker
+
+The spring-boot-parent parent provides a ready to use configuration if you want to build Docker images from your Spring Boot Project.
+
+First you need to configure the `docker.image.repository` and `docker.image.prefix` properties in your `pom.xml`:
+```
+<properties>
+  <!-- docker settings -->
+  <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>
+  <docker.image.prefix>pro-vision</docker.image.prefix>
+</properties>
+```
+
+Afterwards you can provide a Dockerfile which needs to reference your Application's Main Class:
+```
+FROM adoptopenjdk/openjdk11-openj9:latest
+VOLUME /tmp
+ARG DEPENDENCY=target/dependency
+COPY ${DEPENDENCY}/BOOT-INF/lib /app/lib
+COPY ${DEPENDENCY}/META-INF /app/META-INF
+COPY ${DEPENDENCY}/BOOT-INF/classes /app
+ENTRYPOINT ["java","-cp","app:app/lib/*","org.springframework.samples.petclinic.PetClinicApplication"]
+```
+
+When you now run `mvn clean install dockerfile:build` you'll get the required image.
+
+For further information see:
+* [spotify:dockerfile-maven](https://github.com/spotify/dockerfile-maven)
+* [dev-eth0.de: Dockerize Spring Boot Applications](https://www.dev-eth0.de/2019/07/29/dockerize-spring-boot-applications/)
+
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/de.pro-vision.maven/de.pro-vision.maven.spring.spring-boot-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/de.pro-vision.maven/de.pro-vision.maven.spring.spring-boot-parent)
+

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -146,6 +146,13 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring-boot.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>repackage</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <!-- configuration to build Docker images, disabled by default -->
         <plugin>

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -81,6 +81,11 @@
     <spring-cloud.version>Greenwich.SR2</spring-cloud.version>
     <spring-cloud-netflix.version>2.1.2.RELEASE</spring-cloud-netflix.version>
     <spring-cloud-kubernetes.version>1.0.2.RELEASE</spring-cloud-kubernetes.version>
+
+    <!-- docker settings -->
+    <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>
+    <docker.image.prefix>pro-vision</docker.image.prefix>
+
   </properties>
 
   <dependencyManagement>
@@ -141,6 +146,45 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring-boot.version}</version>
+        </plugin>
+        <!-- configuration to build Docker images, disabled by default -->
+        <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>dockerfile-maven-plugin</artifactId>
+          <version>1.4.12</version>
+          <configuration>
+            <repository>${docker.image.repository}/${docker.image.prefix}/${project.artifactId}</repository>
+            <tag>${buildNumber}</tag>
+            <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
+            <skip>true</skip>
+            <buildArgs>
+              <JAR_FILE>target/${project.build.finalName}.jar.original</JAR_FILE>
+            </buildArgs>
+          </configuration>
+        </plugin>
+        <!-- maven dependency plugin used to unpack the jar for docker images -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <executions>
+            <!-- unpack the resulting jar -->
+            <execution>
+              <id>unpack</id>
+              <phase>package</phase>
+              <goals>
+                <goal>unpack</goal>
+              </goals>
+              <configuration>
+                <artifactItems>
+                  <artifactItem>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>${project.artifactId}</artifactId>
+                    <version>${project.version}</version>
+                  </artifactItem>
+                </artifactItems>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This Pull Request brings in the functionality to build docker images for Spring Boot Applications.
By default it's disabled and needs to be enabled per project. 