### PR TITLE
Separation of Spring Boot Parent into multiple Versions

### DIFF
--- a/maven/spring-boot-parent/README.md
+++ b/maven/spring-boot-parent/README.md
@@ -7,6 +7,8 @@ Defines fixed versions of Spring Boot dependencies based on the following naming
 
 `<version>-<spring-boot-version>` e.g. `1-2.1.8` is the first release for Spring Boot 2.1.8. 
 
+For major version separate folders are create in this repository.
+
 ## Docker
 
 The spring-boot-parent parent provides a ready to use configuration if you want to build Docker images from your Spring Boot Project.

--- a/maven/spring-boot-parent/changes.xml
+++ b/maven/spring-boot-parent/changes.xml
@@ -23,6 +23,21 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1-2.2.0RC1" date="not released">
+      <action type="add" dev="amuthmann">
+        Parent for Spring Boot 2.2.0RC1
+      </action>
+    </release>
+
+    <release version="1-2.1.9" date="not released">
+      <action type="add" dev="amuthmann">
+        Add Docker configuration
+      </action>
+      <action type="update" dev="amuthmann">
+        Update to Spring Boot 2.1.9
+      </action>
+    </release>
+
     <release version="1-2.1.8" date="not released">
       <action type="add" dev="amuthmann">
         Initial release.

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -38,10 +38,7 @@
 
   <modules>
     <module>v2.1.x</module>
-    <!--
-    Disabled as the dependencies are not available in maven central yet 
     <module>v2.2.x</module>
-    -->
   </modules>
 
   <build>

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -38,7 +38,10 @@
 
   <modules>
     <module>v2.1.x</module>
+    <!--
+    Disabled as the dependencies are not available in maven central yet 
     <module>v2.2.x</module>
+    -->
   </modules>
 
   <build>

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   #%L
-  pro!vision GmbH
+  wcm.io
   %%
-  Copyright (C) pro!vision GmbH
+  Copyright (C) 2019 pro!vision GmbH
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,240 +19,50 @@
   #L%
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>de.pro-vision.maven</groupId>
-    <artifactId>de.pro-vision.maven.global-parent</artifactId>
-    <version>33</version>
-    <relativePath/>
+    <groupId>de.pro-vision.build-tools</groupId>
+    <artifactId>de.pro-vision.build-tools.root</artifactId>
+    <version>1-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <groupId>de.pro-vision.maven.spring</groupId>
-  <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
-  <version>1-2.1.9-SNAPSHOT</version>
+  <artifactId>de.pro-vision.maven.spring.root</artifactId>
+  <version>1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>de.pro-vision.maven.spring.spring-boot-parent</name>
-  <description>Parent for Spring Boot projects using the pro-vision parent as baseline.</description>
-  <url>https://github.com/pro-vision/pv-build-tools</url>
+  <name>Spring Boot Parent Root</name>
 
-  <scm>
-    <connection>scm:git:https://github.com/pro-vision/pv-build-tools.git</connection>
-    <developerConnection>scm:git:https://github.com/pro-vision/pv-build-tools.git</developerConnection>
-    <url>https://github.com/pro-vision/pv-build-tools</url>
-    <tag>HEAD</tag>
-  </scm>
-
-  <inceptionYear>2019</inceptionYear>
-
-  <organization>
-    <name>pro!vision GmbH</name>
-    <url>http://www.pro-vision.de</url>
-  </organization>
-
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>pro!vision GmbH</name>
-      <organization>pro!vision GmbH</organization>
-      <organizationUrl>http://www.pro-vision.de</organizationUrl>
-    </developer>
-  </developers>
-
-  <properties>
-
-    <!-- distribution settings -->
-    <distribution.snapshotRepositoryId>ossrh</distribution.snapshotRepositoryId>
-    <distribution.snapshotRepositoryUrl>https://oss.sonatype.org/content/repositories/snapshots</distribution.snapshotRepositoryUrl>
-    <distribution.releaseRepositoryId>ossrh</distribution.releaseRepositoryId>
-    <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
-
-    <!-- versions -->
-    <spring-boot.version>2.1.9.RELEASE</spring-boot.version>
-    <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
-    <spring-cloud-netflix.version>2.1.3.RELEASE</spring-cloud-netflix.version>
-    <spring-cloud-kubernetes.version>1.0.3.RELEASE</spring-cloud-kubernetes.version>
-
-    <!-- docker settings -->
-    <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>
-    <docker.image.prefix>pro-vision</docker.image.prefix>
-
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-autoconfigure</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-configuration-processor</artifactId>
-        <optional>true</optional>
-        <version>${spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies</artifactId>
-        <version>${spring-cloud.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-netflix</artifactId>
-        <version>${spring-cloud-netflix.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-netflix-dependencies</artifactId>
-        <version>${spring-cloud-netflix.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
-        <version>${spring-cloud-kubernetes.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+  <modules>
+    <module>v2.1.x</module>
+    <module>v2.2.x</module>
+  </modules>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>${spring-boot.version}</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>repackage</goal>
-                <goal>build-info</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <!-- configuration to build Docker images, disabled by default -->
-        <plugin>
-          <groupId>com.spotify</groupId>
-          <artifactId>dockerfile-maven-plugin</artifactId>
-          <!-- Do not upgrade to 1.4.11 or later due to https://github.com/spotify/dockerfile-maven/issues/308 -->
-          <version>1.4.10</version>
-          <configuration>
-            <repository>${docker.image.repository}/${docker.image.prefix}/${project.artifactId}</repository>
-            <tag>${buildNumber}</tag>
-            <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
-            <skip>true</skip>
-            <buildArgs>
-              <JAR_FILE>target/${project.build.finalName}.jar.original</JAR_FILE>
-            </buildArgs>
-          </configuration>
-        </plugin>
-        <!-- maven dependency plugin used to unpack the jar for docker images -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <executions>
-            <!-- unpack the resulting jar -->
-            <execution>
-              <id>unpack</id>
-              <phase>package</phase>
-              <goals>
-                <goal>unpack</goal>
-              </goals>
-              <configuration>
-                <artifactItems>
-                  <artifactItem>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${project.artifactId}</artifactId>
-                    <version>${project.version}</version>
-                  </artifactItem>
-                </artifactItems>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+    <plugins>
+
+      <!-- do not deploy this hierarchy pom into maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <!-- do not generate site for this project -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skipDeploy>true</skipDeploy>
+        </configuration>
+      </plugin>
+
+    </plugins>
   </build>
-
-  <profiles>
-    <!-- release-profile -->
-    <profile>
-      <id>release-profile</id>
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <!-- sign the build (only for this pom, not inherited)  -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <!-- configure staging process at sonatype (only for this pom, not inherited) -->
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <inherited>false</inherited>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <!-- Deployed artifacts should go to staging to be reviewed before publish -->
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-  <distributionManagement>
-    <repository>
-      <id>${distribution.releaseRepositoryId}</id>
-      <url>${distribution.releaseRepositoryUrl}</url>
-    </repository>
-    <snapshotRepository>
-      <id>${distribution.snapshotRepositoryId}</id>
-      <url>${distribution.snapshotRepositoryUrl}</url>
-    </snapshotRepository>
-  </distributionManagement>
 
 </project>

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -3,7 +3,7 @@
   #%L
   pro!vision GmbH
   %%
-  Copyright (C) 2019 pro!vision GmbH
+  Copyright (C) pro!vision GmbH
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>de.pro-vision.maven.spring</groupId>
   <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
-  <version>2-2.1.10-SNAPSHOT</version>
+  <version>1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Spring Boot Parent Root</name>

--- a/maven/spring-boot-parent/pom.xml
+++ b/maven/spring-boot-parent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   #%L
-  wcm.io
+  pro!vision GmbH
   %%
   Copyright (C) 2019 pro!vision GmbH
   %%
@@ -31,11 +31,11 @@
   </parent>
 
   <groupId>de.pro-vision.maven.spring</groupId>
-  <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
+  <artifactId>de.pro-vision.maven.spring.spring-boot-parent.root</artifactId>
   <version>1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Spring Boot Parent Root</name>
+  <name>Spring Boot Parent - Root</name>
 
   <modules>
     <module>v2.1.x</module>
@@ -79,69 +79,7 @@
     <distribution.releaseRepositoryId>ossrh</distribution.releaseRepositoryId>
     <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
 
-    <!-- versions -->
-    <spring-boot.version>2.1.10.RELEASE</spring-boot.version>
-    <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
-    <spring-cloud-netflix.version>2.1.3.RELEASE</spring-cloud-netflix.version>
-    <spring-cloud-kubernetes.version>1.0.3.RELEASE</spring-cloud-kubernetes.version>
-
-    <!-- docker settings -->
-    <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>
-    <docker.image.prefix>pro-vision</docker.image.prefix>
-
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-autoconfigure</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-configuration-processor</artifactId>
-        <optional>true</optional>
-        <version>${spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies</artifactId>
-        <version>${spring-cloud.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-netflix</artifactId>
-        <version>${spring-cloud-netflix.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-netflix-dependencies</artifactId>
-        <version>${spring-cloud-netflix.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
-        <version>${spring-cloud-kubernetes.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
 
   <build>
     <plugins>

--- a/maven/spring-boot-parent/v2.1.x/changes.xml
+++ b/maven/spring-boot-parent/v2.1.x/changes.xml
@@ -23,7 +23,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="2-2.1.10" date="not released">
+    <release version="1-2.1.11" date="2019-12-05">
+      <action type="update" dev="amuthmann">
+        Update to Spring Boot 2.1.11
+      </action>
+      <action type="update" dev="amuthmann">
+        Update spring-cloud dependencies
+      </action>
       <action type="update" dev="sseifert">
         Update to de.pro-vision.maven.global-parent 34.
       </action>

--- a/maven/spring-boot-parent/v2.1.x/pom.xml
+++ b/maven/spring-boot-parent/v2.1.x/pom.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  pro!vision GmbH
+  %%
+  Copyright (C) pro!vision GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.pro-vision.maven</groupId>
+    <artifactId>de.pro-vision.maven.global-parent</artifactId>
+    <version>33</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>de.pro-vision.maven.spring</groupId>
+  <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
+  <version>1-2.1.9-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>de.pro-vision.maven.spring.spring-boot-parent</name>
+  <description>Parent for Spring Boot projects using the pro-vision parent as baseline.</description>
+  <url>https://github.com/pro-vision/pv-build-tools</url>
+
+  <scm>
+    <connection>scm:git:https://github.com/pro-vision/pv-build-tools.git</connection>
+    <developerConnection>scm:git:https://github.com/pro-vision/pv-build-tools.git</developerConnection>
+    <url>https://github.com/pro-vision/pv-build-tools</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <inceptionYear>2019</inceptionYear>
+
+  <organization>
+    <name>pro!vision GmbH</name>
+    <url>http://www.pro-vision.de</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>pro!vision GmbH</name>
+      <organization>pro!vision GmbH</organization>
+      <organizationUrl>http://www.pro-vision.de</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+
+    <!-- distribution settings -->
+    <distribution.snapshotRepositoryId>ossrh</distribution.snapshotRepositoryId>
+    <distribution.snapshotRepositoryUrl>https://oss.sonatype.org/content/repositories/snapshots</distribution.snapshotRepositoryUrl>
+    <distribution.releaseRepositoryId>ossrh</distribution.releaseRepositoryId>
+    <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
+
+    <!-- versions -->
+    <spring-boot.version>2.1.9.RELEASE</spring-boot.version>
+    <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+    <spring-cloud-netflix.version>2.1.3.RELEASE</spring-cloud-netflix.version>
+    <spring-cloud-kubernetes.version>1.0.3.RELEASE</spring-cloud-kubernetes.version>
+
+    <!-- docker settings -->
+    <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>
+    <docker.image.prefix>pro-vision</docker.image.prefix>
+
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-configuration-processor</artifactId>
+        <optional>true</optional>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring-cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-netflix</artifactId>
+        <version>${spring-cloud-netflix.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-netflix-dependencies</artifactId>
+        <version>${spring-cloud-netflix.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>repackage</goal>
+                <goal>build-info</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- configuration to build Docker images, disabled by default -->
+        <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>dockerfile-maven-plugin</artifactId>
+          <!-- Do not upgrade to 1.4.11 or later due to https://github.com/spotify/dockerfile-maven/issues/308 -->
+          <version>1.4.10</version>
+          <configuration>
+            <repository>${docker.image.repository}/${docker.image.prefix}/${project.artifactId}</repository>
+            <tag>${buildNumber}</tag>
+            <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
+            <skip>true</skip>
+            <buildArgs>
+              <JAR_FILE>target/${project.build.finalName}.jar.original</JAR_FILE>
+            </buildArgs>
+          </configuration>
+        </plugin>
+        <!-- maven dependency plugin used to unpack the jar for docker images -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <executions>
+            <!-- unpack the resulting jar -->
+            <execution>
+              <id>unpack</id>
+              <phase>package</phase>
+              <goals>
+                <goal>unpack</goal>
+              </goals>
+              <configuration>
+                <artifactItems>
+                  <artifactItem>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>${project.artifactId}</artifactId>
+                    <version>${project.version}</version>
+                  </artifactItem>
+                </artifactItems>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <!-- release-profile -->
+    <profile>
+      <id>release-profile</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- sign the build (only for this pom, not inherited)  -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- configure staging process at sonatype (only for this pom, not inherited) -->
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <inherited>false</inherited>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <!-- Deployed artifacts should go to staging to be reviewed before publish -->
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <distributionManagement>
+    <repository>
+      <id>${distribution.releaseRepositoryId}</id>
+      <url>${distribution.releaseRepositoryUrl}</url>
+    </repository>
+    <snapshotRepository>
+      <id>${distribution.snapshotRepositoryId}</id>
+      <url>${distribution.snapshotRepositoryUrl}</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+</project>

--- a/maven/spring-boot-parent/v2.1.x/pom.xml
+++ b/maven/spring-boot-parent/v2.1.x/pom.xml
@@ -79,8 +79,8 @@
     <!-- versions -->
     <spring-boot.version>2.1.10.RELEASE</spring-boot.version>
     <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
-    <spring-cloud-netflix.version>2.1.3.RELEASE</spring-cloud-netflix.version>
-    <spring-cloud-kubernetes.version>1.0.3.RELEASE</spring-cloud-kubernetes.version>
+    <spring-cloud-netflix.version>2.1.4.RELEASE</spring-cloud-netflix.version>
+    <spring-cloud-kubernetes.version>1.0.4.RELEASE</spring-cloud-kubernetes.version>
 
     <!-- docker settings -->
     <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>

--- a/maven/spring-boot-parent/v2.1.x/pom.xml
+++ b/maven/spring-boot-parent/v2.1.x/pom.xml
@@ -77,8 +77,8 @@
     <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
 
     <!-- versions -->
-    <spring-boot.version>2.1.10.RELEASE</spring-boot.version>
-    <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+    <spring-boot.version>2.1.11.RELEASE</spring-boot.version>
+    <spring-cloud.version>Greenwich.SR4</spring-cloud.version>
     <spring-cloud-netflix.version>2.1.4.RELEASE</spring-cloud-netflix.version>
     <spring-cloud-kubernetes.version>1.0.4.RELEASE</spring-cloud-kubernetes.version>
 

--- a/maven/spring-boot-parent/v2.1.x/pom.xml
+++ b/maven/spring-boot-parent/v2.1.x/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>de.pro-vision.maven.spring</groupId>
   <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
-  <version>2-2.1.10-SNAPSHOT</version>
+  <version>1-2.1.11-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>de.pro-vision.maven.spring.spring-boot-parent</name>

--- a/maven/spring-boot-parent/v2.1.x/pom.xml
+++ b/maven/spring-boot-parent/v2.1.x/pom.xml
@@ -26,13 +26,13 @@
   <parent>
     <groupId>de.pro-vision.maven</groupId>
     <artifactId>de.pro-vision.maven.global-parent</artifactId>
-    <version>33</version>
+    <version>34</version>
     <relativePath/>
   </parent>
 
   <groupId>de.pro-vision.maven.spring</groupId>
   <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
-  <version>1-2.1.9-SNAPSHOT</version>
+  <version>2-2.1.10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>de.pro-vision.maven.spring.spring-boot-parent</name>
@@ -77,7 +77,7 @@
     <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
 
     <!-- versions -->
-    <spring-boot.version>2.1.9.RELEASE</spring-boot.version>
+    <spring-boot.version>2.1.10.RELEASE</spring-boot.version>
     <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
     <spring-cloud-netflix.version>2.1.3.RELEASE</spring-cloud-netflix.version>
     <spring-cloud-kubernetes.version>1.0.3.RELEASE</spring-cloud-kubernetes.version>

--- a/maven/spring-boot-parent/v2.2.x/changes.xml
+++ b/maven/spring-boot-parent/v2.2.x/changes.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  pro!vision GmbH
+  %%
+  Copyright (C) pro!vision GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
+          xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
+  <body>
+
+    <release version="1-2.2.2" date="2019-12-05">
+      <action type="update" dev="amuthmann">
+        Initial Release for 2.2.x
+      </action>
+    </release>
+
+  </body>
+</document>

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -77,7 +77,7 @@
     <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
 
     <!-- versions -->
-    <spring-boot.version>2.2.1-RELEASE</spring-boot.version>
+    <spring-boot.version>2.2.1.RELEASE</spring-boot.version>
     <spring-cloud.version>Hoxton.RELEASE</spring-cloud.version>
     <spring-cloud-netflix.version>2.2.0.RELEASE</spring-cloud-netflix.version>
     <spring-cloud-kubernetes.version>1.1.0.RELEASE</spring-cloud-kubernetes.version>

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -79,8 +79,8 @@
     <!-- versions -->
     <spring-boot.version>2.2.1-RELEASE</spring-boot.version>
     <spring-cloud.version>Hoxton.RELEASE</spring-cloud.version>
-    <spring-cloud-netflix.version>2.2.0.RC1</spring-cloud-netflix.version>
-    <spring-cloud-kubernetes.version>1.1.0.RC1</spring-cloud-kubernetes.version>
+    <spring-cloud-netflix.version>2.2.0.RELEASE</spring-cloud-netflix.version>
+    <spring-cloud-kubernetes.version>1.1.0.RELEASE</spring-cloud-kubernetes.version>
 
     <!-- docker settings -->
     <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>de.pro-vision.maven.spring</groupId>
   <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
-  <version>1-2.2.0-SNAPSHOT</version>
+  <version>1-2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>de.pro-vision.maven.spring.spring-boot-parent</name>
@@ -77,10 +77,10 @@
     <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
 
     <!-- versions -->
-    <spring-boot.version>2.2.0-RELEASE</spring-boot.version>
-    <spring-cloud.version>Hoxton.M3</spring-cloud.version>
-    <spring-cloud-netflix.version>2.2.0.M3</spring-cloud-netflix.version>
-    <spring-cloud-kubernetes.version>1.1.0.M3</spring-cloud-kubernetes.version>
+    <spring-boot.version>2.2.1-RELEASE</spring-boot.version>
+    <spring-cloud.version>Hoxton.RELEASE</spring-cloud.version>
+    <spring-cloud-netflix.version>2.2.0.RC1</spring-cloud-netflix.version>
+    <spring-cloud-kubernetes.version>1.1.0.RC1</spring-cloud-kubernetes.version>
 
     <!-- docker settings -->
     <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  pro!vision GmbH
+  %%
+  Copyright (C) pro!vision GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.pro-vision.maven</groupId>
+    <artifactId>de.pro-vision.maven.global-parent</artifactId>
+    <version>33</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>de.pro-vision.maven.spring</groupId>
+  <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
+  <version>1-2.2.0.RC1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>de.pro-vision.maven.spring.spring-boot-parent</name>
+  <description>Parent for Spring Boot projects using the pro-vision parent as baseline.</description>
+  <url>https://github.com/pro-vision/pv-build-tools</url>
+
+  <scm>
+    <connection>scm:git:https://github.com/pro-vision/pv-build-tools.git</connection>
+    <developerConnection>scm:git:https://github.com/pro-vision/pv-build-tools.git</developerConnection>
+    <url>https://github.com/pro-vision/pv-build-tools</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <inceptionYear>2019</inceptionYear>
+
+  <organization>
+    <name>pro!vision GmbH</name>
+    <url>http://www.pro-vision.de</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>pro!vision GmbH</name>
+      <organization>pro!vision GmbH</organization>
+      <organizationUrl>http://www.pro-vision.de</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+
+    <!-- distribution settings -->
+    <distribution.snapshotRepositoryId>ossrh</distribution.snapshotRepositoryId>
+    <distribution.snapshotRepositoryUrl>https://oss.sonatype.org/content/repositories/snapshots</distribution.snapshotRepositoryUrl>
+    <distribution.releaseRepositoryId>ossrh</distribution.releaseRepositoryId>
+    <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
+
+    <!-- versions -->
+    <spring-boot.version>2.2.0.RC1</spring-boot.version>
+    <spring-cloud.version>Hoxton.M3</spring-cloud.version>
+    <spring-cloud-netflix.version>2.2.0.M3</spring-cloud-netflix.version>
+    <spring-cloud-kubernetes.version>1.1.0.M3</spring-cloud-kubernetes.version>
+
+    <!-- docker settings -->
+    <docker.image.repository>YOUR-DOCKER-REGISTRY</docker.image.repository>
+    <docker.image.prefix>pro-vision</docker.image.prefix>
+
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-configuration-processor</artifactId>
+        <optional>true</optional>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring-cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-netflix</artifactId>
+        <version>${spring-cloud-netflix.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-netflix-dependencies</artifactId>
+        <version>${spring-cloud-netflix.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>repackage</goal>
+                <goal>build-info</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- configuration to build Docker images, disabled by default -->
+        <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>dockerfile-maven-plugin</artifactId>
+          <!-- Do not upgrade to 1.4.11 or later due to https://github.com/spotify/dockerfile-maven/issues/308 -->
+          <version>1.4.10</version>
+          <configuration>
+            <repository>${docker.image.repository}/${docker.image.prefix}/${project.artifactId}</repository>
+            <tag>${buildNumber}</tag>
+            <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
+            <skip>true</skip>
+            <buildArgs>
+              <JAR_FILE>target/${project.build.finalName}.jar.original</JAR_FILE>
+            </buildArgs>
+          </configuration>
+        </plugin>
+        <!-- maven dependency plugin used to unpack the jar for docker images -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <executions>
+            <!-- unpack the resulting jar -->
+            <execution>
+              <id>unpack</id>
+              <phase>package</phase>
+              <goals>
+                <goal>unpack</goal>
+              </goals>
+              <configuration>
+                <artifactItems>
+                  <artifactItem>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>${project.artifactId}</artifactId>
+                    <version>${project.version}</version>
+                  </artifactItem>
+                </artifactItems>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <!-- release-profile -->
+    <profile>
+      <id>release-profile</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- sign the build (only for this pom, not inherited)  -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- configure staging process at sonatype (only for this pom, not inherited) -->
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <inherited>false</inherited>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <!-- Deployed artifacts should go to staging to be reviewed before publish -->
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <distributionManagement>
+    <repository>
+      <id>${distribution.releaseRepositoryId}</id>
+      <url>${distribution.releaseRepositoryUrl}</url>
+    </repository>
+    <snapshotRepository>
+      <id>${distribution.snapshotRepositoryId}</id>
+      <url>${distribution.snapshotRepositoryUrl}</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+</project>

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>de.pro-vision.maven.spring</groupId>
   <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
-  <version>1-2.2.0.RC1-SNAPSHOT</version>
+  <version>1-2.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>de.pro-vision.maven.spring.spring-boot-parent</name>
@@ -77,7 +77,7 @@
     <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
 
     <!-- versions -->
-    <spring-boot.version>2.2.0.RC1</spring-boot.version>
+    <spring-boot.version>2.2.0-RELEASE</spring-boot.version>
     <spring-cloud.version>Hoxton.M3</spring-cloud.version>
     <spring-cloud-netflix.version>2.2.0.M3</spring-cloud-netflix.version>
     <spring-cloud-kubernetes.version>1.1.0.M3</spring-cloud-kubernetes.version>

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>de.pro-vision.maven</groupId>
     <artifactId>de.pro-vision.maven.global-parent</artifactId>
-    <version>33</version>
+    <version>34</version>
     <relativePath/>
   </parent>
 

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>de.pro-vision.maven.spring</groupId>
   <artifactId>de.pro-vision.maven.spring.spring-boot-parent</artifactId>
-  <version>1-2.2.1-SNAPSHOT</version>
+  <version>1-2.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>de.pro-vision.maven.spring.spring-boot-parent</name>

--- a/maven/spring-boot-parent/v2.2.x/pom.xml
+++ b/maven/spring-boot-parent/v2.2.x/pom.xml
@@ -77,7 +77,7 @@
     <distribution.releaseRepositoryUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distribution.releaseRepositoryUrl>
 
     <!-- versions -->
-    <spring-boot.version>2.2.1.RELEASE</spring-boot.version>
+    <spring-boot.version>2.2.2.RELEASE</spring-boot.version>
     <spring-cloud.version>Hoxton.RELEASE</spring-cloud.version>
     <spring-cloud-netflix.version>2.2.0.RELEASE</spring-cloud-netflix.version>
     <spring-cloud-kubernetes.version>1.1.0.RELEASE</spring-cloud-kubernetes.version>


### PR DESCRIPTION
Please have a look into this MR. I tried to find a way which allows us to maintain multiple parents for different Spring Boot Versions. I think we should be fine with those subfolders, what do you think?

Do we need to maintain separate changes.xml for each parent or can we keep it in the root?
